### PR TITLE
feat(distro): add new queue per distro

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -187,6 +187,7 @@ class Worker:
         self,
         functions: Sequence[Union[Function, 'WorkerCoroutine']] = (),
         *,
+        distribution_index: int = None,
         queue_name: Optional[str] = default_queue_name,
         cron_jobs: Optional[Sequence[CronJob]] = None,
         redis_settings: Optional[RedisSettings] = None,
@@ -224,6 +225,10 @@ class Worker:
                 queue_name = redis_pool.default_queue_name
             else:
                 raise ValueError('If queue_name is absent, redis_pool must be present.')
+
+        if distribution_index is not None:
+            queue_name = f'{queue_name}_{distribution_index}'
+
         self.queue_name = queue_name
         self.cron_jobs: List[CronJob] = []
         if cron_jobs is not None:


### PR DESCRIPTION
In this PR I have implemented a mechanism to use different queue per data center. By passing `distribution` parameter like "5:2:1" for example, the jobs will be distributed between queues like this:
5 task in first queue
2 task in the second one
and 1 in third queue
then we need to specify `distribution_index` in each server to say to which queue index the tasks should be read in this worker. We can pass this index by using environment variable